### PR TITLE
Defer model defaults to provider SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Authentication:
 - Claude Code: sign in with a Claude subscription or use an Anthropic Console API key.
 
 Model selection:
-- Codex models are configured via Codex (or pass `model` to the `codex_sdk` tool). The default SmartGPT models are `gpt-5-mini-codex` (reasoning) and `gpt-5-codex` (context). 
-- Claude Code supports model aliases and full model names. You can set the model via `/model`, `claude --model`, `ANTHROPIC_MODEL`, or your settings file. The `claude_code_sdk` tool accepts `model` too.
+- Codex models are configured via Codex (or pass `model` to the `codex_sdk` tool). If you omit `reasoningModel`/`contextModel`, SmartGPT lets the Codex SDK choose its default.
+- Claude Code supports model aliases and full model names. You can set the model via `/model`, `claude --model`, `ANTHROPIC_MODEL`, or your settings file. If you omit `reasoningModel`/`contextModel`, SmartGPT lets the Claude SDK choose its default.
 
 Note: The Claude Code SDK was renamed to the Claude Agent SDK. This repo uses the new package name but still supports the old one if you have it installed.
 

--- a/example.ts
+++ b/example.ts
@@ -8,7 +8,7 @@ const ENABLE_EXPERIMENTAL_FEATURES = true;
 // Create a main SmartGPT instance (without Neo4j)
 const smartGPT = new SmartGPT({
   agentProvider: "codex",
-  // Optional: override models for Codex or Claude Code
+  // Optional: override models for Codex or Claude Code (SDK defaults are used if omitted)
   // reasoningModel: "gpt-5-mini-codex",
   // contextModel: "gpt-5-codex",
 

--- a/src/core/smartGPT.ts
+++ b/src/core/smartGPT.ts
@@ -39,8 +39,8 @@ export class SmartGPT {
   private memory!: MemoryStore;
   private retriever!: Retriever;
   private neo4jAvailable = false;
-  private readonly reasoningModel: string;
-  private readonly contextModel: string;
+  private readonly reasoningModel: string | undefined;
+  private readonly contextModel: string | undefined;
   private deepx: DeepExplorer | null = null;
   private memvid: MemvidMemory | null = null;
   private readonly agentProvider: SmartOpts["agentProvider"];
@@ -51,9 +51,15 @@ export class SmartGPT {
     if (opts.serperApiKey) process.env.SERPER_API_KEY = opts.serperApiKey;
 
     // Models setup
-    this.reasoningModel = opts.reasoningModel ?? "gpt-5-mini-codex";
-    this.contextModel = opts.contextModel ?? "gpt-5-codex";
     this.agentProvider = opts.agentProvider ?? "codex";
+    const providerDefaultModel =
+      this.agentProvider === "claude"
+        ? opts.claude?.model
+        : this.agentProvider === "codex"
+          ? opts.codex?.model
+          : opts.codex?.model ?? opts.claude?.model;
+    this.reasoningModel = opts.reasoningModel ?? providerDefaultModel;
+    this.contextModel = opts.contextModel ?? providerDefaultModel;
     this.codexOptions = opts.codex;
     this.claudeOptions = opts.claude;
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -49,7 +49,9 @@ export interface SmartOpts {
   claude?: {
     model?: string;
     maxTurns?: number;
-    systemPrompt?: string;
+    systemPrompt?:
+      | string
+      | { type: "preset"; preset: "claude_code"; append?: string };
     allowedTools?: string[];
     cwd?: string;
   };


### PR DESCRIPTION
Stop hardcoding Codex model defaults and defer to SDK defaults unless explicitly set. Fix Claude schema prompting to work with preset system prompts. Update docs/types for the new model and prompt handling.